### PR TITLE
Daily activity screen

### DIFF
--- a/lib/TranquilForestLandingPage.dart
+++ b/lib/TranquilForestLandingPage.dart
@@ -55,12 +55,19 @@ class TranquilForestLandingPage extends StatelessWidget {
               // Activity for Meditation Station
               activityCard('Meditation Station', context, Icons.headset,
                   'Listen to calming sounds and nature noises.',
-                  builder: (context) => MeditationStation()),
+                  builder: (context) => MeditationStation(),
+                // colors
+                cardColor: Colors.white.withOpacity(0.9), shadowColor: Colors.black.withOpacity(0.3), iconBackgroundColor: Colors.teal[700],iconColor:  Colors.white, textColor: Colors.teal[700], subTextColor: Colors.teal[600]
+              ),
 
               // Activity for Goal Setting
               activityCard('Twilight Alley', context, Icons.flag,
                   'Journal some of your thoughts',
-                  builder: (context) => TwilightAlleyIntro()),
+                  builder: (context) => TwilightAlleyIntro(),
+                  // colors
+                  cardColor: Colors.white.withOpacity(0.9), shadowColor: Colors.black.withOpacity(0.3), iconBackgroundColor: Colors.teal[700],iconColor:  Colors.white, textColor: Colors.teal[700], subTextColor: Colors.teal[600]
+              ),
+
             ],
           ),
         ),

--- a/lib/TranquilForestLandingPage.dart
+++ b/lib/TranquilForestLandingPage.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'screens/shared/activity_widget.dart';
 import 'screens/activities/meditation_station.dart';
 import 'screens/activities/twilight_alley_intro.dart';
 
@@ -52,66 +53,15 @@ class TranquilForestLandingPage extends StatelessWidget {
               const SizedBox(height: 30),
 
               // Activity for Meditation Station
-              _activityCard('Meditation Station', context, Icons.headset,
-                  'Listen to calming sounds and nature noises.', builder: (context)=> MeditationStation()),
+              activityCard('Meditation Station', context, Icons.headset,
+                  'Listen to calming sounds and nature noises.',
+                  builder: (context) => MeditationStation()),
 
               // Activity for Goal Setting
-              _activityCard('Twilight Alley', context, Icons.flag,
-                  'Journal some of your thoughts', builder: (context)=> TwilightAlleyIntro()),
+              activityCard('Twilight Alley', context, Icons.flag,
+                  'Journal some of your thoughts',
+                  builder: (context) => TwilightAlleyIntro()),
             ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  // Method to create activity cards with placeholders for future functionality
-  Widget _activityCard(String activityName, BuildContext context, IconData icon,
-      String description,
-      {Widget Function(BuildContext buildcontext)? builder = null}) {
-    return GestureDetector(
-      onTap: builder == null? () {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('$activityName feature is under construction!'),
-            duration: const Duration(seconds: 2),
-          ),
-        );
-      }:() {
-        Navigator.push(
-            context,
-            MaterialPageRoute(
-                builder: builder
-            ));
-      },
-      child: Card(
-        color: Colors.white.withOpacity(0.9),
-        margin: const EdgeInsets.only(bottom: 20),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(18),
-        ),
-        elevation: 10,
-        shadowColor: Colors.black.withOpacity(0.3),
-        child: ListTile(
-          leading: CircleAvatar(
-            backgroundColor: Colors.teal[700],
-            child: Icon(icon, color: Colors.white, size: 32),
-          ),
-          title: Text(
-            activityName,
-            style: TextStyle(
-              fontSize: 20,
-              fontWeight: FontWeight.bold,
-              color: Colors.teal[700],
-              letterSpacing: 1.0,
-            ),
-          ),
-          subtitle: Text(
-            description,
-            style: TextStyle(
-              fontSize: 16,
-              color: Colors.teal[600],
-            ),
           ),
         ),
       ),

--- a/lib/achievements_screen.dart
+++ b/lib/achievements_screen.dart
@@ -88,11 +88,14 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
         ],
       ),
       bottomNavigationBar: CustomBottomNavigationBar(
-        selectedIndex: 1,
+        selectedIndex: 2,
         onItemTapped: (index) {
           if (index == 0) {
             Navigator.pushReplacementNamed(context, '/'); // Navigate to Home
-          } else if (index == 2) {
+          } else if(index == 1){
+            Navigator.pushReplacementNamed(context, '/todays_activities');
+          }
+          else if (index == 3) {
             Navigator.pushReplacementNamed(context, '/settings'); // Navigate to Settings
           }
         },

--- a/lib/custom_bottom_navigation_bar.dart
+++ b/lib/custom_bottom_navigation_bar.dart
@@ -21,6 +21,9 @@ class CustomBottomNavigationBar extends StatelessWidget {
           icon: Icon(Icons.home),
           label: 'Home',
         ),
+        BottomNavigationBarItem(icon: Icon(Icons.calendar_today),
+            label: 'Daily Activities'
+        ),
         BottomNavigationBarItem(
           icon: Icon(Icons.emoji_events),
           label: 'Achievements',
@@ -30,10 +33,10 @@ class CustomBottomNavigationBar extends StatelessWidget {
           label: 'Settings',
         ),
       ],
+      type: BottomNavigationBarType.fixed,
       selectedItemColor: Colors.blueAccent,
       unselectedItemColor: Colors.grey,
       backgroundColor: Colors.black,
-      type: BottomNavigationBarType.fixed,
       iconSize: 30,
     );
   }

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -80,6 +80,9 @@ class HomeScreen extends StatelessWidget {
             icon: Icon(Icons.home),
             label: 'Home',
           ),
+          BottomNavigationBarItem(icon: Icon(Icons.calendar_today),
+          label: 'Daily Activities'
+          ),
           BottomNavigationBarItem(
             icon: Icon(Icons.emoji_events),
             label: 'Achievements',
@@ -89,10 +92,14 @@ class HomeScreen extends StatelessWidget {
             label: 'Settings',
           ),
         ],
+        type: BottomNavigationBarType.fixed,
         onTap: (index) {
-          if (index == 1) {
+          if(index == 1){
+            Navigator.pushNamed(context,'/todays_activities');
+          }
+          else if (index == 2) {
             Navigator.pushNamed(context, '/achievements');
-          } else if (index == 2) {
+          } else if (index == 3) {
             Navigator.pushNamed(context, '/settings');
           }
         },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'home_screen.dart';
 import 'achievements_screen.dart';
 import 'settings_screen.dart';
+import 'screens/todays_activities.dart';
 
 void main() {
   runApp(const CalmQuestApp());
@@ -17,6 +18,7 @@ class CalmQuestApp extends StatelessWidget {
       initialRoute: '/',
       routes: {
         '/': (context) => const HomeScreen(),
+        '/todays_activities': (context)=> const TodaysActivitiesScreen(),
         '/achievements': (context) => const AchievementsScreen(),
         '/settings': (context) => const SettingsScreen(),
       },

--- a/lib/screens/activities/meditation_station.dart
+++ b/lib/screens/activities/meditation_station.dart
@@ -1,18 +1,18 @@
 import 'dart:async';
 
+import 'package:calm_quest/screens/shared/activity_app_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/services.dart';
 import '../../storage.dart';
 import '../../AudioManager.dart';
 import 'package:path/path.dart' as path;
-import 'dart:developer';
 
 class AudioPlayerScreen extends StatefulWidget {
   const AudioPlayerScreen(
       {Key? key,
-        required String this.audioFilePath,
-        required Storage this.storage})
+      required String this.audioFilePath,
+      required Storage this.storage})
       : super(key: key);
   final String audioFilePath;
   final Storage storage;
@@ -26,6 +26,7 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
   late AudioManager _audioManager;
   final Storage storage;
   bool isPlaying = false;
+  bool _activityCompleted = false;
   final String audioFilePath;
 
   _AudioPlayerScreenState(
@@ -42,13 +43,26 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
 
   Future<void> asyncInit() async {
     DateTime? completion_date = (await storage.getActivityLogs(
-        [ActivityName.values[1]]))[ActivityName.values[1]]![0]
-    ['completion_date'] as DateTime?;
+            [ActivityName.values[1]]))[ActivityName.values[1]]![0]
+        ['completion_date'] as DateTime?;
     DateTime now = DateTime.now().toUtc();
     now = DateTime.utc(now.year, now.month, now.day);
     if (completion_date == null || now.isAfter(completion_date)) {
       completionTimer = Timer(Duration(seconds: 30), () {
+        debugPrint('Activity completed');
+        _activityCompleted = true;
         storage.addActivityLog(ActivityName.values[1], audioFilePath);
+        setState(() {
+
+        });
+      });
+    } else{
+      completionTimer = Timer(Duration(seconds: 3), () {
+        debugPrint('Activity completed');
+        _activityCompleted = true;
+        setState(() {
+
+        });
       });
     }
     _audioManager.playAudio(audioFilePath, loop: true);
@@ -64,18 +78,10 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: Text("Meditation Station",
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 24,
-                letterSpacing: 1.2,
-              )),
-          backgroundColor: Colors.deepPurple[800],
-          elevation: 0,
-        ),
+        appBar: activityAppBar('Meditation Station', Colors.deepPurple[800]!,
+            context, _activityCompleted),
         body: Container(
-          decoration: BoxDecoration(color:Colors.deepPurple[600]),
+          decoration: BoxDecoration(color: Colors.deepPurple[600]),
           child: Center(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -116,6 +122,7 @@ class _MeditationStationState extends State<MeditationStation> {
   late String _dropdownValue;
   late Storage storage;
   List<String>? audioList;
+  bool _activityCompleted = false;
 
   @override
   void initState() {
@@ -142,16 +149,8 @@ class _MeditationStationState extends State<MeditationStation> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text("Meditation Station",
-            style: TextStyle(
-              fontWeight: FontWeight.bold,
-              fontSize: 24,
-              letterSpacing: 1.2,
-            )),
-        backgroundColor: Colors.deepPurple[800],
-        elevation: 0,
-      ),
+      appBar: activityAppBar('Meditation Station', Colors.deepPurple[800]!,
+          context, _activityCompleted),
       body: Container(
         child: Center(
           child: Column(
@@ -179,14 +178,14 @@ class _MeditationStationState extends State<MeditationStation> {
                       });
                     },
                     items:
-                    audioList?.map<DropdownMenuItem<String>>((String val) {
-                      return DropdownMenuItem(
-                          value: val,
-                          child: Text(path
-                              .basenameWithoutExtension(val)
-                              .replaceAll('_', ' ')));
-                    }).toList() ??
-                        [],
+                        audioList?.map<DropdownMenuItem<String>>((String val) {
+                              return DropdownMenuItem(
+                                  value: val,
+                                  child: Text(path
+                                      .basenameWithoutExtension(val)
+                                      .replaceAll('_', ' ')));
+                            }).toList() ??
+                            [],
                     dropdownColor: Colors.deepPurpleAccent[100],
                   ),
                 ),
@@ -198,10 +197,13 @@ class _MeditationStationState extends State<MeditationStation> {
                     context,
                     MaterialPageRoute(
                         builder: (context) => AudioPlayerScreen(
-                          audioFilePath: _dropdownValue,
-                          storage: storage,
-                        )),
-                  );
+                              audioFilePath: _dropdownValue,
+                              storage: storage,
+                            )),
+                  ).then((value) {
+                    _activityCompleted = value as bool;
+                    setState(() {});
+                  });
                 },
                 child: const Text("Go to Audio Player"),
               ),

--- a/lib/screens/activities/meditation_station.dart
+++ b/lib/screens/activities/meditation_station.dart
@@ -49,20 +49,14 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
     now = DateTime.utc(now.year, now.month, now.day);
     if (completion_date == null || now.isAfter(completion_date)) {
       completionTimer = Timer(Duration(seconds: 30), () {
-        debugPrint('Activity completed');
         _activityCompleted = true;
         storage.addActivityLog(ActivityName.values[1], audioFilePath);
-        setState(() {
-
-        });
+        setState(() {});
       });
     } else{
       completionTimer = Timer(Duration(seconds: 3), () {
-        debugPrint('Activity completed');
         _activityCompleted = true;
-        setState(() {
-
-        });
+        setState(() {});
       });
     }
     _audioManager.playAudio(audioFilePath, loop: true);

--- a/lib/screens/activities/meditation_station.dart
+++ b/lib/screens/activities/meditation_station.dart
@@ -54,7 +54,7 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
         setState(() {});
       });
     } else{
-      completionTimer = Timer(Duration(seconds: 3), () {
+      completionTimer = Timer(Duration(seconds: 30), () {
         _activityCompleted = true;
         setState(() {});
       });

--- a/lib/screens/activities/twilight_alley_activity.dart
+++ b/lib/screens/activities/twilight_alley_activity.dart
@@ -1,3 +1,4 @@
+import 'package:calm_quest/screens/shared/activity_app_bar.dart';
 import 'package:flutter/material.dart';
 import 'dart:async';
 import 'twilight_alley_intro.dart'; // Ensure the import path is correct
@@ -15,6 +16,7 @@ class _TwilightAlleyActivityState extends State<TwilightAlleyActivity>
   late AnimationController _leftStarController;
   late AnimationController _rightStarController;
   late Animation<double> _fadeAnimation;
+  bool _activityCompleted = false;
   final List<String> _prompts = [
     "What made you smile today?",
     "What is something you're grateful for?",
@@ -77,6 +79,7 @@ class _TwilightAlleyActivityState extends State<TwilightAlleyActivity>
         _isPromptVisible = true;
       });
     } else {
+      _activityCompleted = true;
       // Logic for end of prompts (e.g., navigate to a summary page)
       showDialog(
         context: context,
@@ -88,12 +91,14 @@ class _TwilightAlleyActivityState extends State<TwilightAlleyActivity>
               TextButton(
                 onPressed: () {
                   Navigator.of(context).pop();
+                  Navigator.pop(context,true);
+                  /*Navigator.of(context).pop();
                   Navigator.pushReplacement(
                     context,
                     MaterialPageRoute(
                       builder: (context) => const TwilightAlleyIntro(),
                     ),
-                  );
+                  );*/
                 },
                 child: const Text("OK"),
               ),
@@ -107,18 +112,7 @@ class _TwilightAlleyActivityState extends State<TwilightAlleyActivity>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text(
-          'Twilight Alley',
-          style: TextStyle(
-            fontWeight: FontWeight.bold,
-            fontSize: 24,
-            letterSpacing: 1.2,
-          ),
-        ),
-        backgroundColor: Colors.deepPurple[800],
-        elevation: 0,
-      ),
+      appBar: activityAppBar('Twilight Alley', Colors.deepPurple[800]!, context, _activityCompleted),
       body: Container(
         width: double.infinity, // Ensures the container covers full width
         height: double.infinity, // Ensures the container covers full height

--- a/lib/screens/activities/twilight_alley_intro.dart
+++ b/lib/screens/activities/twilight_alley_intro.dart
@@ -70,7 +70,7 @@ class _TwilightAlleyIntroState extends State<TwilightAlleyIntro>
 
   Future<void> setActivityCompleted(Future<dynamic> val) async{
     _activityCompleted = (await val) as bool;
-    debugPrint("Activity is ${_activityCompleted?'complete':'not complete'}");
+    setState(() {});
   }
 
   @override

--- a/lib/screens/activities/twilight_alley_intro.dart
+++ b/lib/screens/activities/twilight_alley_intro.dart
@@ -1,3 +1,4 @@
+import 'package:calm_quest/screens/shared/activity_app_bar.dart';
 import 'package:flutter/material.dart';
 import 'dart:async';
 
@@ -13,6 +14,7 @@ class TwilightAlleyIntro extends StatefulWidget {
 
 class _TwilightAlleyIntroState extends State<TwilightAlleyIntro>
     with TickerProviderStateMixin {
+  bool _activityCompleted = false;
   bool _isTextVisible = false;
   bool _isMoonScaled = false;
   bool _isBlurbVisible = false;
@@ -66,21 +68,15 @@ class _TwilightAlleyIntroState extends State<TwilightAlleyIntro>
     super.dispose();
   }
 
+  Future<void> setActivityCompleted(Future<dynamic> val) async{
+    _activityCompleted = (await val) as bool;
+    debugPrint("Activity is ${_activityCompleted?'complete':'not complete'}");
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text(
-          'Twilight Alley',
-          style: TextStyle(
-            fontWeight: FontWeight.bold,
-            fontSize: 24,
-            letterSpacing: 1.2,
-          ),
-        ),
-        backgroundColor: Colors.deepPurple[800],
-        elevation: 0,
-      ),
+      appBar: activityAppBar('Twilight Alley', Colors.deepPurple[800]!, context, _activityCompleted),
       body: Container(
         width: double.infinity,
         height: double.infinity,
@@ -172,10 +168,10 @@ class _TwilightAlleyIntroState extends State<TwilightAlleyIntro>
                   MaterialPageRoute(builder: (context) => const TwilightAlleyLoad()),
                 );
                 Timer(const Duration(milliseconds: 3500), () {
-                  Navigator.pushReplacement(
+                  setActivityCompleted(Navigator.pushReplacement(
                     context,
                     MaterialPageRoute(builder: (context) => const TwilightAlleyActivity()),
-                  );
+                  ));
                 });
               },
               child: const Text('Start'),

--- a/lib/screens/shared/activity_app_bar.dart
+++ b/lib/screens/shared/activity_app_bar.dart
@@ -1,0 +1,20 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+
+AppBar activityAppBar(String title, Color backgroundColor, BuildContext context, bool activityCompleted) {
+  return AppBar(
+      title: Text(
+        title,
+        style: const TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 24,
+          letterSpacing: 1.2,
+        ),
+      ),
+      backgroundColor: backgroundColor,
+      elevation: 0,
+      leading: BackButton(
+        color: Colors.white,
+        onPressed: () {Navigator.pop(context, activityCompleted);},
+      ));
+}

--- a/lib/screens/shared/activity_widget.dart
+++ b/lib/screens/shared/activity_widget.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+// Method to create activity cards with placeholders for future functionality
+Widget activityCard(String activityName, BuildContext context, IconData icon,
+    String description,
+    {Widget Function(BuildContext buildcontext)? builder = null}) {
+  return GestureDetector(
+    onTap: builder == null? () {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('$activityName feature is under construction!'),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+    }:() {
+      Navigator.push(
+          context,
+          MaterialPageRoute(
+              builder: builder
+          ));
+    },
+    child: Card(
+      color: Colors.white.withOpacity(0.9),
+      margin: const EdgeInsets.only(bottom: 20),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(18),
+      ),
+      elevation: 10,
+      shadowColor: Colors.black.withOpacity(0.3),
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: Colors.teal[700],
+          child: Icon(icon, color: Colors.white, size: 32),
+        ),
+        title: Text(
+          activityName,
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: Colors.teal[700],
+            letterSpacing: 1.0,
+          ),
+        ),
+        subtitle: Text(
+          description,
+          style: TextStyle(
+            fontSize: 16,
+            color: Colors.teal[600],
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/screens/shared/activity_widget.dart
+++ b/lib/screens/shared/activity_widget.dart
@@ -4,7 +4,8 @@ import 'package:flutter/material.dart';
 Widget activityCard(String activityName, BuildContext context, IconData icon, String description,
     {
       Widget Function(BuildContext buildcontext)? builder = null,
-      Color? cardColor, Color? shadowColor, Color? textColor, Color? subTextColor, Color? iconColor, Color? iconBackgroundColor
+      Color? cardColor, Color? shadowColor, Color? textColor, Color? subTextColor, Color? iconColor, Color? iconBackgroundColor,
+      Function(dynamic)? onPop
     }
     ) {
   return GestureDetector(
@@ -16,12 +17,12 @@ Widget activityCard(String activityName, BuildContext context, IconData icon, St
         ),
       );
     }:() {
-      Navigator.push(
-          context,
-          MaterialPageRoute(
-              builder: builder
-          ));
-    },
+      if(onPop == null) {
+              Navigator.push(context, MaterialPageRoute(builder: builder));
+            } else{
+        Navigator.push(context,MaterialPageRoute(builder:builder)).then(onPop);
+      }
+          },
     child: Card(
       color: cardColor,
       margin: const EdgeInsets.only(bottom: 20),

--- a/lib/screens/shared/activity_widget.dart
+++ b/lib/screens/shared/activity_widget.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 
 // Method to create activity cards with placeholders for future functionality
-Widget activityCard(String activityName, BuildContext context, IconData icon,
-    String description,
-    {Widget Function(BuildContext buildcontext)? builder = null}) {
+Widget activityCard(String activityName, BuildContext context, IconData icon, String description,
+    {
+      Widget Function(BuildContext buildcontext)? builder = null,
+      Color? cardColor, Color? shadowColor, Color? textColor, Color? subTextColor, Color? iconColor, Color? iconBackgroundColor
+    }
+    ) {
   return GestureDetector(
     onTap: builder == null? () {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -20,24 +23,24 @@ Widget activityCard(String activityName, BuildContext context, IconData icon,
           ));
     },
     child: Card(
-      color: Colors.white.withOpacity(0.9),
+      color: cardColor,
       margin: const EdgeInsets.only(bottom: 20),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(18),
       ),
       elevation: 10,
-      shadowColor: Colors.black.withOpacity(0.3),
+      shadowColor: shadowColor,
       child: ListTile(
         leading: CircleAvatar(
-          backgroundColor: Colors.teal[700],
-          child: Icon(icon, color: Colors.white, size: 32),
+          backgroundColor: iconBackgroundColor,
+          child: Icon(icon, color:iconColor, size: 32),
         ),
         title: Text(
           activityName,
           style: TextStyle(
             fontSize: 20,
             fontWeight: FontWeight.bold,
-            color: Colors.teal[700],
+            color: textColor,
             letterSpacing: 1.0,
           ),
         ),
@@ -45,7 +48,7 @@ Widget activityCard(String activityName, BuildContext context, IconData icon,
           description,
           style: TextStyle(
             fontSize: 16,
-            color: Colors.teal[600],
+            color: subTextColor,
           ),
         ),
       ),

--- a/lib/screens/todays_activities.dart
+++ b/lib/screens/todays_activities.dart
@@ -1,3 +1,4 @@
+import '../custom_bottom_navigation_bar.dart';
 import 'shared/activity_widget.dart';
 import 'package:flutter/material.dart';
 import '../storage.dart';
@@ -114,6 +115,19 @@ class _TodaysActivitiesScreenState extends State<TodaysActivitiesScreen> {
             ],
           ),
         ),
+      ),
+      bottomNavigationBar: CustomBottomNavigationBar(
+        selectedIndex: 1,
+        onItemTapped: (index) {
+          if (index == 0) {
+            Navigator.pushReplacementNamed(context, '/'); // Navigate to Home
+          } else if(index == 2){
+            Navigator.pushReplacementNamed(context, '/achievements');
+          }
+          else if (index == 3) {
+            Navigator.pushReplacementNamed(context, '/settings'); // Navigate to Settings
+          }
+        },
       ),
     );
   }

--- a/lib/screens/todays_activities.dart
+++ b/lib/screens/todays_activities.dart
@@ -16,17 +16,20 @@ class _TodaysActivitiesScreenState extends State<TodaysActivitiesScreen>{
   static const Map<ActivityName, StatefulWidget Function()> activityNameToFunction = const{
     ActivityName.meditation_station:
     MeditationStation.new,
-    ActivityName.twilight_alley: TwilightAlleyIntro.new
+    ActivityName.twilight_alley: TwilightAlleyIntro.new,
+    ActivityName.breathe: MeditationStation.new
   };
 
   static const Map<ActivityName, IconData> activityNameIcons = const{
     ActivityName.meditation_station: Icons.headset,
     ActivityName.twilight_alley: Icons.flag,
+    ActivityName.breathe: Icons.phone_in_talk
   };
 
   static const Map<ActivityName, String> activityNameDescription = const{
     ActivityName.meditation_station: 'Listen to calming sounds and nature noises.',
     ActivityName.twilight_alley:                   'Journal some of your thoughts',
+    ActivityName.breathe: 'This activity is a work in progress!'
   };
 
   List<ActivityName> activities = [];

--- a/lib/screens/todays_activities.dart
+++ b/lib/screens/todays_activities.dart
@@ -4,53 +4,54 @@ import '../storage.dart';
 import 'activities/meditation_station.dart';
 import 'activities/twilight_alley_intro.dart';
 
-class TodaysActivitiesScreen extends StatefulWidget{
+class TodaysActivitiesScreen extends StatefulWidget {
   const TodaysActivitiesScreen({super.key});
+
   @override
   State<TodaysActivitiesScreen> createState() => _TodaysActivitiesScreenState();
 }
 
-class _TodaysActivitiesScreenState extends State<TodaysActivitiesScreen>{
+class _TodaysActivitiesScreenState extends State<TodaysActivitiesScreen> {
   late Storage storage;
 
-  static const Map<ActivityName, StatefulWidget Function()> activityNameToFunction = const{
-    ActivityName.meditation_station:
-    MeditationStation.new,
+  static const Map<ActivityName, StatefulWidget Function()>
+      activityNameToFunction = const {
+    ActivityName.meditation_station: MeditationStation.new,
     ActivityName.twilight_alley: TwilightAlleyIntro.new,
     ActivityName.breathe: MeditationStation.new
   };
 
-  static const Map<ActivityName, IconData> activityNameIcons = const{
+  static const Map<ActivityName, IconData> activityNameIcons = const {
     ActivityName.meditation_station: Icons.headset,
     ActivityName.twilight_alley: Icons.flag,
     ActivityName.breathe: Icons.phone_in_talk
   };
 
-  static const Map<ActivityName, String> activityNameDescription = const{
-    ActivityName.meditation_station: 'Listen to calming sounds and nature noises.',
-    ActivityName.twilight_alley:                   'Journal some of your thoughts',
+  static const Map<ActivityName, String> activityNameDescription = const {
+    ActivityName.meditation_station:
+        'Listen to calming sounds and nature noises.',
+    ActivityName.twilight_alley: 'Journal some of your thoughts',
     ActivityName.breathe: 'This activity is a work in progress!'
   };
 
-  List<Map<String,Object>> activities = [];
-
+  List<Map<String, Object>> activities = [];
 
   _TodaysActivitiesScreenState();
 
   @override
-  void initState(){
+  void initState() {
     super.initState();
     asyncInit();
   }
 
-  Future<void> asyncInit() async{
+  Future<void> asyncInit() async {
     storage = await Storage.create();
     activities = await storage.dailyReset();
-    setState((){});
+    setState(() {});
   }
 
   @override
-  Widget build(BuildContext context){
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text(
@@ -81,10 +82,35 @@ class _TodaysActivitiesScreenState extends State<TodaysActivitiesScreen>{
                 ),
               ),
               const SizedBox(height: 30),
-              ...(activities.map(
-                      (activity)=>
-                          activityCard(activity['activity'].toString(), context, (activity['completed'] as bool)? Icons.check : activityNameIcons[activity['activity']]!, activityNameDescription[activity['activity']]! + ((activity['completed'] as bool)? '\nYou already completed this activity today.':''), builder: (context)=> activityNameToFunction[activity['activity']]!(),
-                              cardColor: (activity['completed'] as bool)?Colors.grey.withOpacity(0.9):Colors.white.withOpacity(0.9), shadowColor: Colors.black.withOpacity(0.3), iconBackgroundColor: Colors.amber[700], iconColor: Colors.white, textColor: Colors.amber[900], subTextColor: Colors.amber[800]             )))
+              ...(List<Widget>.generate(activities.length, (int index) {
+                var activity = activities[index];
+                return activityCard(
+                    activity['activity'].toString(),
+                    context,
+                    (activity['completed'] as bool)
+                        ? Icons.check
+                        : activityNameIcons[activity['activity']]!,
+                    activityNameDescription[activity['activity']]! +
+                        ((activity['completed'] as bool)
+                            ? '\nYou already completed this activity today.'
+                            : ''),
+                    builder: (context) =>
+                        activityNameToFunction[activity['activity']]!(),
+                    cardColor: (activity['completed'] as bool)
+                        ? Colors.grey.withOpacity(0.9)
+                        : Colors.white.withOpacity(0.9),
+                    shadowColor: Colors.black.withOpacity(0.3),
+                    iconBackgroundColor: Colors.amber[700],
+                    iconColor: Colors.white,
+                    textColor: Colors.amber[900],
+                    subTextColor: Colors.amber[800],
+                    onPop: (value) {
+                      storage.setDailyCompleted(index + 1);
+                      activities[index]['completed'] = value as bool;
+                      debugPrint("Set activity $index completion to ${value as bool?'true':'false'}");
+                      setState(() {});
+                    });
+              }))
             ],
           ),
         ),

--- a/lib/screens/todays_activities.dart
+++ b/lib/screens/todays_activities.dart
@@ -1,0 +1,90 @@
+import 'shared/activity_widget.dart';
+import 'package:flutter/material.dart';
+import '../storage.dart';
+import 'activities/meditation_station.dart';
+import 'activities/twilight_alley_intro.dart';
+
+class TodaysActivitiesScreen extends StatefulWidget{
+  const TodaysActivitiesScreen({super.key});
+  @override
+  State<TodaysActivitiesScreen> createState() => _TodaysActivitiesScreenState();
+}
+
+class _TodaysActivitiesScreenState extends State<TodaysActivitiesScreen>{
+  late Storage storage;
+
+  static const Map<ActivityName, StatefulWidget Function()> activityNameToFunction = const{
+    ActivityName.meditation_station:
+    MeditationStation.new,
+    ActivityName.twilight_alley: TwilightAlleyIntro.new
+  };
+
+  static const Map<ActivityName, IconData> activityNameIcons = const{
+    ActivityName.meditation_station: Icons.headset,
+    ActivityName.twilight_alley: Icons.flag,
+  };
+
+  static const Map<ActivityName, String> activityNameDescription = const{
+    ActivityName.meditation_station: 'Listen to calming sounds and nature noises.',
+    ActivityName.twilight_alley:                   'Journal some of your thoughts',
+  };
+
+  List<ActivityName> activities = [];
+
+
+  _TodaysActivitiesScreenState();
+
+  @override
+  void initState(){
+    super.initState();
+    asyncInit();
+  }
+
+  Future<void> asyncInit() async{
+    storage = await Storage.create();
+    activities = await storage.dailyReset();
+    setState((){});
+  }
+
+  @override
+  Widget build(BuildContext context){
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          "Today's Activities",
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: 24,
+            letterSpacing: 1.2,
+          ),
+        ),
+        backgroundColor: Colors.amber[800],
+        elevation: 0,
+      ),
+      body: Container(
+        color: Colors.amber[700],
+        child: Padding(
+          padding: const EdgeInsets.all(20.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                "Here are the activities for today!",
+                style: TextStyle(
+                  fontSize: 28,
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                  letterSpacing: 1.2,
+                ),
+              ),
+              const SizedBox(height: 30),
+              ...(activities.map(
+                      (activityName)=>
+                          activityCard(activityName.toString(), context, activityNameIcons[activityName]!, activityNameDescription[activityName]!, builder: (context)=> activityNameToFunction[activityName]!(), cardColor: Colors.white.withOpacity(0.9), shadowColor: Colors.black.withOpacity(0.3), iconBackgroundColor: Colors.amber[700], iconColor: Colors.white, textColor: Colors.amber[900], subTextColor: Colors.amber[800]             )))
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/todays_activities.dart
+++ b/lib/screens/todays_activities.dart
@@ -32,7 +32,7 @@ class _TodaysActivitiesScreenState extends State<TodaysActivitiesScreen>{
     ActivityName.breathe: 'This activity is a work in progress!'
   };
 
-  List<ActivityName> activities = [];
+  List<Map<String,Object>> activities = [];
 
 
   _TodaysActivitiesScreenState();
@@ -82,8 +82,9 @@ class _TodaysActivitiesScreenState extends State<TodaysActivitiesScreen>{
               ),
               const SizedBox(height: 30),
               ...(activities.map(
-                      (activityName)=>
-                          activityCard(activityName.toString(), context, activityNameIcons[activityName]!, activityNameDescription[activityName]!, builder: (context)=> activityNameToFunction[activityName]!(), cardColor: Colors.white.withOpacity(0.9), shadowColor: Colors.black.withOpacity(0.3), iconBackgroundColor: Colors.amber[700], iconColor: Colors.white, textColor: Colors.amber[900], subTextColor: Colors.amber[800]             )))
+                      (activity)=>
+                          activityCard(activity['activity'].toString(), context, (activity['completed'] as bool)? Icons.check : activityNameIcons[activity['activity']]!, activityNameDescription[activity['activity']]! + ((activity['completed'] as bool)? '\nYou already completed this activity today.':''), builder: (context)=> activityNameToFunction[activity['activity']]!(),
+                              cardColor: (activity['completed'] as bool)?Colors.grey.withOpacity(0.9):Colors.white.withOpacity(0.9), shadowColor: Colors.black.withOpacity(0.3), iconBackgroundColor: Colors.amber[700], iconColor: Colors.white, textColor: Colors.amber[900], subTextColor: Colors.amber[800]             )))
             ],
           ),
         ),

--- a/lib/settings_screen.dart
+++ b/lib/settings_screen.dart
@@ -175,11 +175,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   ],
                 ),
       bottomNavigationBar: CustomBottomNavigationBar(
-        selectedIndex: 2, // Ensure Settings is selected
+        selectedIndex: 3, // Ensure Settings is selected
         onItemTapped: (index) {
           if (index == 0) {
             Navigator.pushReplacementNamed(context, '/'); // Navigate to Home
-          } else if (index == 1) {
+          } else if (index == 1){
+            Navigator.pushReplacementNamed(context, '/todays_activities');
+          } else if (index == 2) {
             Navigator.pushReplacementNamed(context, '/achievements'); // Navigate to Achievements
           }
         },

--- a/lib/storage.dart
+++ b/lib/storage.dart
@@ -1,3 +1,7 @@
+import 'dart:math';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' show join;
@@ -12,6 +16,7 @@ class Storage {
   static const _activityLogTable = 'activity_logs';
   static const _preferencesTable = 'preferences';
   static const _achievementsTable = 'achievements';
+  static const _dailyResetTable = 'last_daily_reset';
 
   Storage._create(Database db) {
     _db = db;
@@ -164,12 +169,7 @@ class Storage {
   ///  await storage.addActivityLog(ActivityName.breathe);
   /// ```
   Future<void> addActivityLog(ActivityName name, String? info) async {
-    int activityId = (await _db.query(
-      _activityTable,
-      columns: ['id'],
-      where: 'name = ?',
-      whereArgs: [name.name],
-    ))[0]['id'] as int;
+    int activityId = await getActivityId(name);
 
     await _db.insert(
       _activityLogTable,
@@ -181,14 +181,19 @@ class Storage {
     );
   }
 
-  /// Delete an activity log entry
-  Future<void> deleteActivityLog(ActivityName activityName) async {
+  Future<int> getActivityId(ActivityName name) async {
     int activityId = (await _db.query(
       _activityTable,
       columns: ['id'],
       where: 'name = ?',
-      whereArgs: [activityName.name],
+      whereArgs: [name.name],
     ))[0]['id'] as int;
+    return activityId;
+  }
+
+  /// Delete an activity log entry
+  Future<void> deleteActivityLog(ActivityName activityName) async {
+    int activityId = await getActivityId(activityName);
     await _db.delete(_activityLogTable, where: 'activity_id = ?', whereArgs: [activityId]);
   }
 
@@ -233,7 +238,70 @@ class Storage {
     });
     await batch.commit(noResult: true);
   }
-/// Retrieves all cues for a specific session ID
+
+  /**
+   * Treeset functions
+   */
+
+  /// Retrieves multiple daily reset info from the database. Specify the date range by setting `startDate` and `endDate`.
+  /// Dates will be sorted from newest to oldest (e.g., today's reset info will appear before yesterday's)
+  /// If `startDate`/`endDate` is not specified, the current date will be used for the respective parameter.
+  Future<List<Map<String,Object?>>> getDailyResetInfo({DateTime? startDate, DateTime? endDate}) async{
+    int startSinceEpoch = startDate != null ? startDate.daysSinceEpoch():DateTime.now().daysSinceEpoch();
+    int endSinceEpoch = endDate != null ? endDate.daysSinceEpoch():DateTime.now().daysSinceEpoch();
+
+    // throw error if start date is after end date
+    if(startSinceEpoch > endSinceEpoch){
+      throw ArgumentError('startDate {$startDate} set after endDate {$endDate}');
+    }
+
+    // Sets the query args based on startDate and endDate being the same
+    String where;
+    List<Object> whereArgs;
+    if(startSinceEpoch == endSinceEpoch){
+      where = 'date == ?';
+      whereArgs = [startSinceEpoch];
+    } else {
+      where = 'date BETWEEN ? AND ?';
+      whereArgs = [startSinceEpoch, endSinceEpoch];
+    }
+
+    // convert the activity IDs to ActivityNames
+    List<Map<String,Object?>> rows = await _db.query(_dailyResetTable, columns: ['date', 'activity_1_id', 'activity_2_id', 'activity_3_id'], where: where, whereArgs: whereArgs, orderBy: 'date DESC',);
+    if(kDebugMode){
+      debugPrint("Fetched ${rows.length} rows from the daily reset table");
+    }
+
+    for(int i = 0; i < rows.length; i++){
+      rows[i]['activity_1_id'] = ActivityName.values[rows[i]['activity_1_id'] as int];
+      rows[i]['activity_2_id'] = ActivityName.values[rows[i]['activity_2_id'] as int];
+      rows[i]['activity_3_id'] = ActivityName.values[rows[i]['activity_3_id'] as int];
+    }
+
+    return rows;
+  }
+
+  /// Resets daily data. Returns the list of ActivityNames selected
+  Future<List<ActivityName>> dailyReset() async{
+    // try to fetch today's daily reset info to ensure it's not already in there
+    List<Map<String,Object?>> latestReset = await getDailyResetInfo();
+    if(latestReset.isNotEmpty){
+      return [latestReset[0]['activity_1_id'] as ActivityName,latestReset[0]['activity_2_id'] as ActivityName,latestReset[0]['activity_3_id'] as ActivityName,];
+    }
+
+    //generate list of activities
+    var rng = Random();
+    List<ActivityName> activities = List<ActivityName>.generate(3, (int index)=>ActivityName.values[rng.nextInt(ActivityName.values.length-1)+1], growable: false);
+    await _db.insert(_dailyResetTable, <String, Object>{
+      'date': DateTime.now().daysSinceEpoch(),
+      'activity_1_id':getActivityId(activities[0]),
+      'activity_2_id':getActivityId(activities[1]),
+      'activity_3_id':getActivityId(activities[2])
+    });
+    return activities;
+  }
+
+  /// Retrieves all cues for a specific session ID
 Future<List<Map<String, dynamic>>> getCuesForSession(int sessionId) async {
   return await _db.query(
     'cues',
@@ -307,20 +375,34 @@ Future<void> insertSession(int sessionId, String name) async {
         'name CHAR(50) NOT NULL,'
         'completion_date INT NULL'
         ');');
-// Create sessions table
-  batch.execute('CREATE TABLE IF NOT EXISTS sessions ('
+
+    // Create sessions table
+    batch.execute('CREATE TABLE IF NOT EXISTS sessions ('
       'id INTEGER PRIMARY KEY AUTOINCREMENT,'
       'name TEXT NOT NULL'
       ');');
 
-  // Create cues table
-  batch.execute('CREATE TABLE IF NOT EXISTS cues ('
+    // Create cues table
+    batch.execute('CREATE TABLE IF NOT EXISTS cues ('
       'id INTEGER PRIMARY KEY AUTOINCREMENT,'
       'session_id INTEGER NOT NULL,'
       'time_sec INTEGER NOT NULL,'
       'message TEXT NOT NULL,'
       'FOREIGN KEY(session_id) REFERENCES sessions(id) ON DELETE CASCADE'
       ');');
+
+    // Create daily_reset table
+    batch.execute('CREATE TABLE IF NOT EXISTS $_dailyResetTable ('
+        'id INTEGER PRIMARY KEY NOT NULL,'
+        'date INT NOT NULL,'
+        'activity_1_id INTEGER NOT NULL,'
+        'activity_2_id INTEGER NOT NULL,'
+        'activity_3_id INTEGER NOT NULL,'
+        'FOREGIN KEY(activity_1_id) REFERENCES $_activityTable(id),'
+        'FOREGIN KEY(activity_2_id) REFERENCES $_activityTable(id),'
+        'FOREGIN KEY(activity_3_id) REFERENCES $_activityTable(id)'
+        ');');
+
     // Insert default preferences into the preferences table
     for (PreferenceName preferenceName in PreferenceName.values) {
       if (preferenceName.value == -1) continue;
@@ -407,6 +489,7 @@ enum PreferenceName {
 enum ActivityName {
   all(-1),
   meditation_station(0),
+  twilight_alley(1),
   breathe(99);
 
   final int value;

--- a/lib/storage.dart
+++ b/lib/storage.dart
@@ -30,7 +30,7 @@ class Storage {
   static Future<Storage> create({String dbName = 'storage.db'}) async {
     var db = await openDatabase(
       join(await getDatabasesPath(), dbName),
-      version: 1, // Ensure the version is specified
+      version: 2, // Ensure the version is specified
       onConfigure: _configureDb,
       onCreate: _initDb,
     );
@@ -294,9 +294,9 @@ class Storage {
     List<ActivityName> activities = List<ActivityName>.generate(3, (int index)=>ActivityName.values[rng.nextInt(ActivityName.values.length-1)+1], growable: false);
     await _db.insert(_dailyResetTable, <String, Object>{
       'date': DateTime.now().daysSinceEpoch(),
-      'activity_1_id':getActivityId(activities[0]),
-      'activity_2_id':getActivityId(activities[1]),
-      'activity_3_id':getActivityId(activities[2])
+      'activity_1_id':await getActivityId(activities[0]),
+      'activity_2_id':await getActivityId(activities[1]),
+      'activity_3_id':await getActivityId(activities[2])
     });
     return activities;
   }
@@ -398,9 +398,10 @@ Future<void> insertSession(int sessionId, String name) async {
         'activity_1_id INTEGER NOT NULL,'
         'activity_2_id INTEGER NOT NULL,'
         'activity_3_id INTEGER NOT NULL,'
-        'FOREGIN KEY(activity_1_id) REFERENCES $_activityTable(id),'
-        'FOREGIN KEY(activity_2_id) REFERENCES $_activityTable(id),'
-        'FOREGIN KEY(activity_3_id) REFERENCES $_activityTable(id)'
+        'activity_completed INTEGER NOT NULL DEFAULT 0,'
+        'FOREIGN KEY(activity_1_id) REFERENCES $_activityTable(id),'
+        'FOREIGN KEY(activity_2_id) REFERENCES $_activityTable(id),'
+        'FOREIGN KEY(activity_3_id) REFERENCES $_activityTable(id)'
         ');');
 
     // Insert default preferences into the preferences table
@@ -489,12 +490,15 @@ enum PreferenceName {
 enum ActivityName {
   all(-1),
   meditation_station(0),
-  twilight_alley(1),
-  breathe(99);
+  twilight_alley(1);
 
   final int value;
 
   const ActivityName(this.value);
+  @override
+  String toString(){
+    return name.split('_').map((s)=> {s = "${s[0].toUpperCase()}${s.substring(1)}"}).join(' ');
+  }
 }
 
 enum Achievement {

--- a/lib/storage.dart
+++ b/lib/storage.dart
@@ -266,9 +266,6 @@ class Storage {
 
     // convert the activity IDs to ActivityNames
     List<Map<String,Object?>> rows = await _db.query(_dailyResetTable, columns: ['date', 'activity_1_id', 'activity_2_id', 'activity_3_id', 'activity_completed'], where: where, whereArgs: whereArgs, orderBy: 'date DESC',);
-    if(kDebugMode){
-      debugPrint("Fetched ${rows.length} rows from the daily reset table.");
-    }
     List<Map<String,Object>?> parsedRows = [];
     for(int i = 0; i < rows.length; i++){
       parsedRows.add(<String,Object>{
@@ -296,7 +293,6 @@ class Storage {
     List<int> pickRand = List<int>.generate(ActivityName.values.length-1, (i)=>i+1);
     pickRand.shuffle();
     List<ActivityName> activities = List<ActivityName>.generate(3, (int index)=>ActivityName.values[pickRand[index]], growable: false);
-    debugPrint("${activities[0].name},${activities[1].name},${activities[2].name}");
     await _db.insert(_dailyResetTable, <String, Object>{
       'date': DateTime.now().daysSinceEpoch(),
       'activity_1_id':await getActivityId(activities[0]),

--- a/lib/storage.dart
+++ b/lib/storage.dart
@@ -306,6 +306,13 @@ class Storage {
     return List<Map<String,Object>>.generate(3, (int index)=>{'activity':activities[index],'completed':false});
   }
 
+  Future<void> setDailyCompleted(int activityNumber) async{
+    var row = (await _db.query(_dailyResetTable,columns: ['activity_completed','id'], where: 'date == ?', whereArgs: [DateTime.now().daysSinceEpoch()], limit: 1))[0];
+    int completionInfo = row['activity_completed'] as int;
+    completionInfo |= (1 << (activityNumber-1));
+    await _db.update(_dailyResetTable, {'activity_completed': completionInfo}, where: 'id == ?', whereArgs: [row['id']]);
+  }
+
   /// Retrieves all cues for a specific session ID
 Future<List<Map<String, dynamic>>> getCuesForSession(int sessionId) async {
   return await _db.query(


### PR DESCRIPTION
# Summary
Creates user story R1 (today's activities screen). The screen grabs 3 random activities (unique from one another) for the user to complete. This uses the info in the `ActivityName` enum and a couple of lists to link the screens to those activities.

Currently, the "breathe` activity is connected to Meditation Station. This is intended since the system won't work without 3 unique activities in ActivityName. I'll fix that once we get a third activity made.

# Other changes
* Created `last_daily_reset` table so daily activities don't get regenerated everytime the app is reopened. See the design doc for the schema.
* Updated achievements and preferences table to have the name be unique.
* Changed the database version
* Moved the widget for activity cards from Tranquil Forest into `lib/screens/shared/activity_widget.dart`.
* Moved the activity app bar from Meditation Station and Twilight Alley into `lib/screens/shared/activity_app_bar.dart`.
* Fixed Twilight Alley back button going back to the intro screen instead of the previous screen after completing the activity.
* Added some info to be passed back on popping certain screens.
* Added a function to fetch an activity's ID. This might be unnecessary since we should be able to use the enum value
* Added a `toString()` function for the `ActivityName` enum.
* Fixed some formatting issues in various files