### PR TITLE
Set compileSdkVersion to 35

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -9,6 +9,7 @@ android {
     namespace = "com.example.mindfulness_app"
     compileSdk = 35
     ndkVersion = flutter.ndkVersion
+    compileSdkVersion = 35
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Stops a warning that was thrown when building the project for Android API 35.