### PR TITLE
Twilight Alley Sentiment Analysis and Modifications to Metrics Page

### DIFF
--- a/lib/screens/activities/twilight_alley_activity.dart
+++ b/lib/screens/activities/twilight_alley_activity.dart
@@ -1,11 +1,12 @@
 import 'package:calm_quest/screens/shared/activity_app_bar.dart';
 import 'package:flutter/material.dart';
 import 'dart:async';
-// Ensure the import path is correct
+import 'twilight_alley_intro.dart';
 import '../../storage.dart';
+import 'package:dart_sentiment/dart_sentiment.dart';
 
 class TwilightAlleyActivity extends StatefulWidget {
-  const TwilightAlleyActivity({super.key});
+  const TwilightAlleyActivity({Key? key}) : super(key: key);
 
   @override
   _TwilightAlleyActivityState createState() => _TwilightAlleyActivityState();
@@ -40,14 +41,18 @@ class _TwilightAlleyActivityState extends State<TwilightAlleyActivity>
   int _currentEmojiPromptIndex = 0;
   final List<String> _emojiResponses = [];
 
-  // New variables for points and sad emoji detection
+  // New variables for points, sentiment, and sad emoji detection
   int _totalEmojiPoints = 0;
   bool _sadEmojiSelected = false;
+  int _cumulativeSentimentScore = 0; // cumulative sentiment score
   final Map<String, int> _emojiPoints = {
     "happy": 3,
     "neutral": 2,
     "sad": 1,
   };
+
+  // Create a Sentiment analyzer instance
+  final Sentiment sentiment = Sentiment();
 
   @override
   void initState() {
@@ -114,6 +119,7 @@ class _TwilightAlleyActivityState extends State<TwilightAlleyActivity>
           ? 'Total Emoji Points: $_totalEmojiPoints (Less than 13)'
           : 'Total Emoji Points: $_totalEmojiPoints';
 
+      // Save the activity log as before
       var future = storage.addActivityLog(
         ActivityName.twilight_alley,
         [
@@ -121,31 +127,22 @@ class _TwilightAlleyActivityState extends State<TwilightAlleyActivity>
           ..._emojiResponses,
           pointsMessage,
           'Sad Emoji Selected: ${_sadEmojiSelected ? 'Yes' : 'No'}',
+          'Cumulative Sentiment Score: $_cumulativeSentimentScore',
         ].join('\n'),
       );
-      showDialog(
-        context: context,
-        builder: (context) {
-          return AlertDialog(
-            title: const Text("Session Complete"),
-            content: Text(
-              "Your responses:\n"
-              "${_userResponses.join("\n")}\n"
-              "${_emojiResponses.join("\n")}\n\n"
-              "$pointsMessage\n"
-              "Sad Emoji Selected: ${_sadEmojiSelected ? 'Yes' : 'No'}",
-            ),
-            actions: [
-              TextButton(
-                onPressed: () {
-                  Navigator.of(context).pop();
-                  Navigator.pop(context, true);
-                },
-                child: const Text("OK"),
-              ),
-            ],
-          );
-        },
+
+      // Instead of a dialog, navigate to a summary screen that uses the same styling.
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (context) => SessionSummaryScreen(
+            userResponses: _userResponses,
+            emojiResponses: _emojiResponses,
+            pointsMessage: pointsMessage,
+            sadEmojiSelected: _sadEmojiSelected,
+            cumulativeSentimentScore: _cumulativeSentimentScore,
+          ),
+        ),
       );
       await future;
     }
@@ -172,56 +169,77 @@ class _TwilightAlleyActivityState extends State<TwilightAlleyActivity>
       } else {
         _currentEmojiPromptIndex++; // Increment index to move beyond last prompt
         _activityCompleted = true;
-        _getNextPrompt(); // Transition to the completion dialog
+        _getNextPrompt(); // Transition to the summary screen
       }
     });
   }
 
-  Widget _buildEmojiPrompt() {
+  // Widget to build animated sentiment gauge (text label)
+  Widget _buildSentimentGauge() {
+    Color scoreColor;
+    if (_cumulativeSentimentScore > 0) {
+      scoreColor = Colors.green;
+    } else if (_cumulativeSentimentScore < 0) {
+      scoreColor = Colors.red;
+    } else {
+      scoreColor = Colors.grey;
+    }
+    return AnimatedDefaultTextStyle(
+      duration: const Duration(milliseconds: 500),
+      style: TextStyle(
+        fontSize: 20,
+        color: scoreColor,
+        fontWeight: FontWeight.bold,
+      ),
+      child: Text("Cumulative Sentiment Score: $_cumulativeSentimentScore"),
+    );
+  }
+
+  // Widget to build animated sentiment bar showing negative and positive proportions.
+  Widget _buildSentimentBar(BuildContext context) {
+    double maxScore = 20.0; // Maximum absolute score assumed for display
+    double totalWidth = MediaQuery.of(context).size.width - 40; // Some padding
+    double center = totalWidth / 2;
+    double positiveWidth = 0.0;
+    double negativeWidth = 0.0;
+    if (_cumulativeSentimentScore > 0) {
+      positiveWidth =
+      (totalWidth * (_cumulativeSentimentScore.clamp(0, maxScore) / maxScore));
+    } else if (_cumulativeSentimentScore < 0) {
+      negativeWidth =
+      (totalWidth * ((-_cumulativeSentimentScore).clamp(0, maxScore) / maxScore));
+    }
     return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        AnimatedOpacity(
-          duration: const Duration(milliseconds: 500),
-          opacity: _isPromptVisible ? 1.0 : 0.0,
-          child: Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Text(
-              _emojiPrompts[_currentEmojiPromptIndex],
-              style: const TextStyle(
-                fontSize: 26, // Increased font size
-                color: Colors.white,
-                fontWeight: FontWeight.bold,
-              ),
-              textAlign: TextAlign.center,
-            ),
-          ),
-        ),
-        const SizedBox(height: 30), // Increased space between text and icons
-        AnimatedOpacity(
-          duration: const Duration(milliseconds: 500),
-          opacity: _isPromptVisible ? 1.0 : 0.0,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        Container(
+          width: totalWidth,
+          height: 10,
+          color: Colors.grey[300],
+          child: Stack(
             children: [
-              IconButton(
-                icon: const Icon(Icons.sentiment_very_satisfied,
-                    size: 60, color: Colors.green), // Increased size
-                onPressed: () => _handleEmojiResponse("happy"),
+              Positioned(
+                left: center - negativeWidth,
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 500),
+                  width: negativeWidth,
+                  height: 10,
+                  color: Colors.red,
+                ),
               ),
-              IconButton(
-                icon: const Icon(Icons.sentiment_neutral,
-                    size: 60, color: Colors.yellow), // Increased size
-                onPressed: () => _handleEmojiResponse("neutral"),
-              ),
-              IconButton(
-                icon: const Icon(Icons.sentiment_dissatisfied,
-                    size: 60, color: Colors.red), // Increased size
-                onPressed: () => _handleEmojiResponse("sad"),
+              Positioned(
+                left: center,
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 500),
+                  width: positiveWidth,
+                  height: 10,
+                  color: Colors.green,
+                ),
               ),
             ],
           ),
         ),
+        const SizedBox(height: 8),
+        _buildSentimentGauge(),
       ],
     );
   }
@@ -229,11 +247,11 @@ class _TwilightAlleyActivityState extends State<TwilightAlleyActivity>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: activityAppBar('Twilight Alley', Colors.deepPurple[800]!, context,
-          _activityCompleted),
+      appBar: activityAppBar(
+          'Twilight Alley', Colors.deepPurple[800]!, context, _activityCompleted),
       body: Container(
-        width: double.infinity, // Ensures the container covers full width
-        height: double.infinity, // Ensures the container covers full height
+        width: double.infinity, // Full width
+        height: double.infinity, // Full height
         decoration: const BoxDecoration(
           gradient: LinearGradient(
             colors: [Colors.deepPurpleAccent, Colors.purple],
@@ -241,17 +259,24 @@ class _TwilightAlleyActivityState extends State<TwilightAlleyActivity>
             end: Alignment.bottomRight,
           ),
         ),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            if (_currentPromptIndex < _prompts.length) ...[
-              const SizedBox(height: 50),
-              _buildTextPrompt(),
-            ] else if (_currentEmojiPromptIndex < _emojiPrompts.length) ...[
-              const SizedBox(height: 50),
-              _buildEmojiPrompt(),
+        child: SingleChildScrollView(
+          // For smaller screens
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              // Display live sentiment bar at the top
+              const SizedBox(height: 20),
+              _buildSentimentBar(context),
+              const SizedBox(height: 20),
+              if (_currentPromptIndex < _prompts.length) ...[
+                const SizedBox(height: 50),
+                _buildTextPrompt(),
+              ] else if (_currentEmojiPromptIndex < _emojiPrompts.length) ...[
+                const SizedBox(height: 50),
+                _buildEmojiPrompt(),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );
@@ -275,11 +300,11 @@ class _TwilightAlleyActivityState extends State<TwilightAlleyActivity>
               ),
             ),
             const SizedBox(width: 20),
-            const AnimatedScale(
+            AnimatedScale(
               scale: 1.2,
-              duration: Duration(seconds: 1),
+              duration: const Duration(seconds: 1),
               curve: Curves.easeInOut,
-              child: Icon(
+              child: const Icon(
                 Icons.nightlight_round,
                 color: Colors.white,
                 size: 80,
@@ -341,6 +366,13 @@ class _TwilightAlleyActivityState extends State<TwilightAlleyActivity>
           ),
           onPressed: () {
             if (_textController.text.isNotEmpty) {
+              // Analyze sentiment of the input and update cumulative score
+              final result = sentiment.analysis(_textController.text, emoji: true);
+              int score = result['score'] as int;
+              setState(() {
+                _cumulativeSentimentScore += score;
+              });
+
               _userResponses.add(_textController.text);
               _getNextPrompt();
             }
@@ -348,6 +380,191 @@ class _TwilightAlleyActivityState extends State<TwilightAlleyActivity>
           child: const Text('Submit'),
         ),
       ],
+    );
+  }
+
+  Widget _buildEmojiPrompt() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        AnimatedOpacity(
+          duration: const Duration(milliseconds: 500),
+          opacity: _isPromptVisible ? 1.0 : 0.0,
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Text(
+              _emojiPrompts[_currentEmojiPromptIndex],
+              style: const TextStyle(
+                fontSize: 26,
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+        const SizedBox(height: 30),
+        AnimatedOpacity(
+          duration: const Duration(milliseconds: 500),
+          opacity: _isPromptVisible ? 1.0 : 0.0,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.sentiment_very_satisfied,
+                    size: 60, color: Colors.green),
+                onPressed: () => _handleEmojiResponse("happy"),
+              ),
+              IconButton(
+                icon: const Icon(Icons.sentiment_neutral,
+                    size: 60, color: Colors.yellow),
+                onPressed: () => _handleEmojiResponse("neutral"),
+              ),
+              IconButton(
+                icon: const Icon(Icons.sentiment_dissatisfied,
+                    size: 60, color: Colors.red),
+                onPressed: () => _handleEmojiResponse("sad"),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// New: A screen to display the session summary with matching styling and animations.
+class SessionSummaryScreen extends StatelessWidget {
+  final List<String> userResponses;
+  final List<String> emojiResponses;
+  final String pointsMessage;
+  final bool sadEmojiSelected;
+  final int cumulativeSentimentScore;
+
+  const SessionSummaryScreen({
+    Key? key,
+    required this.userResponses,
+    required this.emojiResponses,
+    required this.pointsMessage,
+    required this.sadEmojiSelected,
+    required this.cumulativeSentimentScore,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      // Reuse the same background gradient
+      body: Container(
+        width: double.infinity,
+        height: double.infinity,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Colors.deepPurpleAccent, Colors.purple],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: SafeArea(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                // Animated title
+                AnimatedDefaultTextStyle(
+                  duration: const Duration(milliseconds: 500),
+                  style: const TextStyle(
+                    fontSize: 28,
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  child: const Text("Session Summary"),
+                ),
+                const SizedBox(height: 20),
+                // Display cumulative sentiment with animated gauge
+                AnimatedDefaultTextStyle(
+                  duration: const Duration(milliseconds: 500),
+                  style: TextStyle(
+                    fontSize: 20,
+                    color: cumulativeSentimentScore > 0
+                        ? Colors.green
+                        : (cumulativeSentimentScore < 0 ? Colors.red : Colors.grey),
+                    fontWeight: FontWeight.bold,
+                  ),
+                  child: Text("Cumulative Sentiment Score: $cumulativeSentimentScore"),
+                ),
+                const SizedBox(height: 10),
+                // Points message
+                Text(
+                  pointsMessage,
+                  style: const TextStyle(fontSize: 18, color: Colors.white),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 10),
+                // Sad emoji indicator
+                Text(
+                  "Sad Emoji Selected: ${sadEmojiSelected ? 'Yes' : 'No'}",
+                  style: const TextStyle(fontSize: 18, color: Colors.white),
+                  textAlign: TextAlign.center,
+                ),
+                const Divider(color: Colors.white54, height: 40),
+                // Display text responses
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    "Text Responses:",
+                    style: TextStyle(
+                      fontSize: 20,
+                      color: Colors.white.withOpacity(0.9),
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 10),
+                ...userResponses.map((response) => Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Text(
+                    response,
+                    style: const TextStyle(fontSize: 16, color: Colors.white),
+                  ),
+                )),
+                const Divider(color: Colors.white54, height: 40),
+                // Display emoji responses
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    "Emoji Responses:",
+                    style: TextStyle(
+                      fontSize: 20,
+                      color: Colors.white.withOpacity(0.9),
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 10),
+                ...emojiResponses.map((response) => Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Text(
+                    response,
+                    style: const TextStyle(fontSize: 16, color: Colors.white),
+                  ),
+                )),
+                const SizedBox(height: 40),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.deepPurpleAccent,
+                    foregroundColor: Colors.white,
+                  ),
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                  child: const Text("Finish"),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/screens/activities/twilight_alley_intro.dart
+++ b/lib/screens/activities/twilight_alley_intro.dart
@@ -6,7 +6,7 @@ import '../shared/twilight_alley_load.dart'; // Correct relative path to the loa
 import 'twilight_alley_activity.dart'; // Correct relative path to the activity
 
 class TwilightAlleyIntro extends StatefulWidget {
-  const TwilightAlleyIntro({super.key});
+  const TwilightAlleyIntro({Key? key}) : super(key: key);
 
   @override
   _TwilightAlleyIntroState createState() => _TwilightAlleyIntroState();
@@ -57,8 +57,7 @@ class _TwilightAlleyIntroState extends State<TwilightAlleyIntro>
       vsync: this,
     )..repeat(reverse: true);
 
-    _fadeAnimation =
-        Tween<double>(begin: 0.3, end: 1.0).animate(_fadeController);
+    _fadeAnimation = Tween<double>(begin: 0.3, end: 1.0).animate(_fadeController);
   }
 
   @override
@@ -69,16 +68,18 @@ class _TwilightAlleyIntroState extends State<TwilightAlleyIntro>
     super.dispose();
   }
 
-  Future<void> setActivityCompleted(Future<dynamic> val) async {
-    _activityCompleted = (await val) as bool;
-    setState(() {});
+  // Modified: Accept a nullable bool and default to false if null.
+  void setActivityCompleted(bool? completed) {
+    setState(() {
+      _activityCompleted = completed ?? false;
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: activityAppBar('Twilight Alley', Colors.deepPurple[800]!, context,
-          _activityCompleted),
+      appBar: activityAppBar(
+          'Twilight Alley', Colors.deepPurple[800]!, context, _activityCompleted),
       body: Container(
         width: double.infinity,
         height: double.infinity,
@@ -167,15 +168,15 @@ class _TwilightAlleyIntroState extends State<TwilightAlleyIntro>
               onPressed: () {
                 Navigator.push(
                   context,
-                  MaterialPageRoute(
-                      builder: (context) => const TwilightAlleyLoad()),
+                  MaterialPageRoute(builder: (context) => const TwilightAlleyLoad()),
                 );
                 Timer(const Duration(milliseconds: 3500), () {
-                  setActivityCompleted(Navigator.pushReplacement(
+                  // Directly set the flag to true instead of passing a Future.
+                  setActivityCompleted(true);
+                  Navigator.pushReplacement(
                     context,
-                    MaterialPageRoute(
-                        builder: (context) => const TwilightAlleyActivity()),
-                  ));
+                    MaterialPageRoute(builder: (context) => const TwilightAlleyActivity()),
+                  );
                 });
               },
               child: const Text('Start'),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  dart_sentiment: ^0.0.9
   sqflite: ^2.3.3+2
   path: ^1.9.0
   meta: ^1.7.0


### PR DESCRIPTION
Added a VADER-Style sentiment analyzer to the written prompt portion. Doesn't take into account for spelling errors. Metrics page at the end got cleaned up to match the theme.

Try prompts like "I had an _awful_ day" or "I liked this _amazing_ project" to see how they impact the cumulative sentiment score

NOTE: Probably gonna need a pre-trained model or LLM API to get effective results at sentiment analysis. The programmatic solution involving lexicons ain't it - this sentiment analyzer would only work in a demo setting